### PR TITLE
Fixes Issue #14 in upstream. Takes server id as env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,11 @@ A URL location of a zip file containing JAR files. The JAR files will be install
 
 Allow insecure SSL connections when downloading files during startup. This applies to keystore downloads, plugin downloads, and server library downloads. By default, insecure connections are disabled but you can enable this option by setting `ALLOW_INSECURE=true`.
 
+<a name="env-server-id"></a>
+#### `SERVER_ID`
+
+Set the `server.id` to a specific value. Use this to preserve or set the server ID across restarts and deployments. Using the env-var is preferred over storing `appdata` persistently
+
 ------------
 
 <a name="other-mirth-properties-options"></a>

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -84,6 +84,11 @@ if ! [ -z "${SESSION_STORE+x}" ]; then
 	fi
 fi
 
+#server ID
+if ! [ -z "${SERVER_ID+x}" ]; then
+  echo -e "server.id = ${SERVER_ID//\//\\/}" > /opt/connect/appdata/server.id
+fi
+
 # merge extra environment variables starting with _MP_ into mirth.properties
 while read -r keyvalue; do
 	KEY="${keyvalue%%=*}"


### PR DESCRIPTION
I added support and documentation to take `SERVER_ID` as an environment variable and write it to `appdata/server.id`.

I tested with:
```
docker build -t connect_local --build-arg ARTIFACT=https://s3.amazonaws.com/downloads.mirthcorp.com/connect/4.1.1.b303/mirthconnect-4.1.1.b303-unix.tar.gz  .
docker run -e SERVER_ID='UwU-pwease-accept-my-peeawr' -p 8443:8443 connect_local  #check server.id file and log in to MC and see the server ID I set        
docker run -p 8443:8443 connect_local #see the normal autogenerated UUID as server ID        
docker run -e SERVER_ID='' -p 8443:8443 connect_local  #ensure blank is handled and server ID is autogenerated
```

<img width="416" alt="image" src="https://user-images.githubusercontent.com/7669292/204897116-a90f4385-7866-49ab-a48c-1383c5229964.png">
