### PR TITLE
Update Mirth Connect package download to version 4.5.2.b363

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
-RUN curl -SL https://s3.amazonaws.com/downloads.mirthcorp.com/connect/4.5.1.b332/mirthconnect-4.5.1.b332-unix.tar.gz \
+RUN curl -SL https://s3.amazonaws.com/downloads.mirthcorp.com/connect/4.5.2.b363/mirthconnect-4.5.2.b363-unix.tar.gz \
     | tar -xzC /opt \
     && mv "/opt/Mirth Connect" /opt/connect
 


### PR DESCRIPTION
Greetings! 😎 

My team ran into an issue where our internal tooling broke when we updated to current `latest` (4.5.2 as of today on Dockerhub.)

It appears the 4.5.1 package version for connect is being used for the 4.5.2 build.

I updated that line to be the 4.5.2 version from your S3 package download endpoint.

It looks like other folks are starting to run into this, as well:
https://github.com/nextgenhealthcare/connect-docker/issues/47

Thank you!